### PR TITLE
Update README to fix broken link to site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portfolio
 
-This repository is a complete redo to my current [blog](jakekinsella.com). This time, making full use of React, Redux, Typescript, and Webpacker. The idea is that this new site will both show off my work and blog posts.
+This repository is a complete redo to my current [blog](https://jakekinsella.com/). This time, making full use of React, Redux, Typescript, and Webpacker. The idea is that this new site will both show off my work and blog posts.
 
 ## TODO
 - Articles


### PR DESCRIPTION
Without specifying a schema in your URL, markdown on github will make a link in the repository itself. This adds the https schema so the blog link points to the correct site.